### PR TITLE
fix how grunt called system jekyll instead of local jekyll

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,16 +37,16 @@ module.exports = function(grunt) {
     },
     bgShell: {
       jekyllBuild : {
-        cmd: 'jekyll build',
+        cmd: 'bundle exec jekyll build',
         bg: false
       },
       // `jekyllWatch` is not used, but here for reference
       jekyllWatch : {
-        cmd: 'jekyll build --watch',
+        cmd: 'bundle exec jekyll build --watch',
         bg: true
       },
       jekyllDev : {
-        cmd: "jekyll serve --baseurl '' --watch",
+        cmd: "bundle exec jekyll serve --baseurl '' --watch",
         bg: true
       }
     },


### PR DESCRIPTION
Currently, I'm getting this error:

```
$ grunt
...
Running "bgShell:jekyllBuild" (bgShell) task
>> /bin/sh: jekyll: command not found
>> Error: Command failed: jekyll build
```

It's because it's calling the system jekyll... which doesn't exist, instead of the version installed by bundler.
