### PR TITLE
Add newsapps styleguide to main nav

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -9,6 +9,9 @@
           </li>
         {% endif %}
       {% endfor %}
+      <li>
+        <a href="//texastribune.github.io/newsapps-styles/">News Apps</a>
+      </li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
This adds newsapps to the main nav so that it's easy to find the newsapps styleguide from here, and we're able to send people to one link for Tribune styleguides.
