### PR TITLE
Update news apps style guide link to be correct

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -10,7 +10,7 @@
         {% endif %}
       {% endfor %}
       <li>
-        <a href="//texastribune.github.io/newsapps-styles/">News Apps</a>
+        <a href="http://apps.texastribune.org/styles/">News Apps</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
This updates the newsapps style guide link to be the most updated.
